### PR TITLE
urlcheck: ensure that httpclient calls are properly drained

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # url-shortener
 
-v0.0.3 : 24 June 2024 : deploy example to GCP
+v0.0.4 : 27 June 2024 : bugfix -- drain httpclient connections
 
 ## Resolve short urls and redirect them
 


### PR DESCRIPTION
Tests showed that after a timeout a client would block. This fixes that.